### PR TITLE
VCPI Support

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -60,9 +60,7 @@
   a) Overview
 
    The 32-bit binary runs in ring 0, 32-bit protected mode with PAE paging
-  enabled. PAE paging is not compatible with legacy 32-bit paging, hence
-  Dos32pae won't run as VCPI client within V86-monitors like (J)EMM386!
-  Also, since it's no DPMI ( although somewhat DPMI-like ), the binary won't
+  enabled. Since it's no DPMI ( although somewhat DPMI-like ), the binary won't
   run in DOS-Boxes - it needs plain DOS!
 
   b) DPMI API

--- a/src/DOS32PAE.asm
+++ b/src/DOS32PAE.asm
@@ -1553,7 +1553,7 @@ doint67 proc
     mov dword ptr [esp].RMCS.rFS,ecx
     mov [esp].RMCS.rSSSP, ecx
     mov edi,esp
-    mov bx,21h
+    mov bx,67h
     mov ax,0300h
     int 31h
     popad

--- a/src/DOS32PAE.asm
+++ b/src/DOS32PAE.asm
@@ -845,9 +845,6 @@ endif
     sti
 
 ;    call HandleRelocs
-    ; deliberate double-fault to test task gate
-    ;mov esp,1
-    ;pushad
 
     jmp cs:[retad]
 


### PR DESCRIPTION
Hello, me again!

After working on dos64stb before, I spent some more time trying to add VCPI support to dos32pae, this time without confining the application to EMS memory.

EMS is still used, but this time it's only to create a buffer for page tables, which are copied from/to XMS memory using the copy2x function. It's less efficient than using Unreal Mode for sure, but it's only used during page table setup, which shouldn't represent a large proportion of any actual workload…

Also, it only works if there's a page frame, which I guess is better than nothing!

This PR also includes a TSS (mandatory for VCPI), and makes the double-fault exception handler into a Task Gate, to prevent triple faults when the stack is messed up.